### PR TITLE
changed copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -10,10 +10,15 @@ Copyright:
 
 License:
 
-  Zabbix is an enterprise-class open source distributed monitoring solution.
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License version 2 as
-  published by the Free Software Foundation.
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
   On Debian GNU/Linux systems, the complete text of the GNU General
   Public License can be found in `/usr/share/common-licenses/GPL-2'.


### PR DESCRIPTION
It's not exactly clear which licence is used, cause you only paste the Zabbix GPL text into copyright. I think we should replace it by the GPLv2 text or 3, whatever your favourite is.